### PR TITLE
Add missing esm restriction

### DIFF
--- a/presets/no-esm.json
+++ b/presets/no-esm.json
@@ -24,7 +24,7 @@
     {
       "allowedVersions": "<6.0.0",
       "matchDatasources": ["npm"],
-      "matchPackageNames": ["find-up"]
+      "matchPackageNames": ["@octokit/core", "find-up"]
     },
     {
       "allowedVersions": "<7.0.0",
@@ -42,14 +42,14 @@
       "matchPackageNames": ["@octokit/plugin-throttling", "@octokit/request"]
     },
     {
-      "allowedVersions": "<15.0.0",
-      "matchDatasources": ["npm"],
-      "matchPackageNames": ["@octokit/graphql-schema"]
-    },
-    {
       "allowedVersions": "<13.0.0",
       "matchDatasources": ["npm"],
       "matchPackageNames": ["@octokit/webhooks"]
+    },
+    {
+      "allowedVersions": "<15.0.0",
+      "matchDatasources": ["npm"],
+      "matchPackageNames": ["@octokit/graphql-schema"]
     },
     {
       "allowedVersions": "<21.0.0",

--- a/presets/no-mui-migration.json
+++ b/presets/no-mui-migration.json
@@ -1,0 +1,14 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "packageRules": [
+    {
+      "allowedVersions": "<5.0.0",
+      "description": [
+        "Do not migrate to Material-UI v5",
+        "https://github.com/backstage/backstage/issues/7094"
+      ],
+      "matchDatasources": ["npm"],
+      "matchPackageNames": ["@mui/material", "@mui/icons-material"]
+    }
+  ]
+}


### PR DESCRIPTION
When renovate tried to apply some Lock file maintenance I have discovered some other dependencies updates that introduces issues due to ESM migration of theses dependencies. So I have updated renovate config to prevent them.